### PR TITLE
[DOCKER-COMPOSE] Création volume pour fichiers CSV

### DIFF
--- a/csv_data/README.md
+++ b/csv_data/README.md
@@ -1,0 +1,3 @@
+## Dossier csv_data
+
+Mettre dans ce dossier, les différentes données CSV qui vont être importées dans la base de données.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
                - "30000:3306"
           volumes:
                - mysql_vol:/var/lib/data
+               - ./csv_data:/csv_data
           environment:
                MYSQL_ROOT_PASSWORD: root
                MYSQL_DATABASE: avions


### PR DESCRIPTION
Pour faciliter l'import des données CSV, sans passer par une copie des fichiers en interne dans le container, on expose les fichiers CSV à l'extérieur du container.