### PR TITLE
[DOCKER-COMPOSE] Ajout d'un volume pour les csv pour phpmyadmin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
           container_name: phpmyadmin-local
           ports:
                - "30080:80"
+          volumes:
+               - ./csv_data:/csv_data
           environment: 
                PMA_HOST: mysql
                MYSQL_ROOT_PASSWORD: root


### PR DESCRIPTION
Pour permettre de tester l'importation des fichiers CSV depuis phpmyadmin, le dossier **csv_data** sera aussi lié au container phpmyadmin.